### PR TITLE
Skip theme values if not typeof string

### DIFF
--- a/packages/tailwind-clamp/lib/index.js
+++ b/packages/tailwind-clamp/lib/index.js
@@ -47,6 +47,7 @@ export default plugin.withOptions(function (options = {}) {
     const variableDefinitions = {};
 
     for (const [name, value] of Object.entries(clampTheme)) {
+      if (typeof value != 'string') continue;
       const firstArg = value.split(',')[0];
       if (isLengthValue(firstArg)) {
         variableDefinitions[name] = value;


### PR DESCRIPTION
I tries the css-variable addition and found a bug that I managed to fix:

There's is a problem where the name of the clamp css variable is parsed as an object (in the example below `{blockspace:0, 'blockspace-sm':0}`. Object can nog be split on the comma ',', so this pull request skips everything if they are not string types.

```
--clamp-blockspace: 3rem, 8rem;
--clamp-blockspace-sm: 2.75rem, 3rem;
```